### PR TITLE
Fixed broken data source, bump version

### DIFF
--- a/geocode.gemspec
+++ b/geocode.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'geocode'
-  s.version = '0.2.1'
+  s.version = '0.2.2'
   s.date = '2010-09-14'
   s.summary = 'Geocoding library and CLI tool'
   s.email = "github@shinybit.com"

--- a/lib/google/geocode.rb
+++ b/lib/google/geocode.rb
@@ -10,7 +10,7 @@ module Google
     end
 
     def do_geocode(location)
-      url = "http://maps.google.com/maps/geo?sensor=false&key=#{@api_key}&output=json&q=#{location}&client=#{@client}"
+      url = "https://maps.googleapis.com/maps/api/geocode/json?sensor=false&key=#{@api_key}&output=json&address=#{location}&client=#{@client}"
       resp = Net::HTTP.get_response(URI.parse(url))
       data = resp.body
 


### PR DESCRIPTION
Google's geocoding API has switched to using https://maps.googleapis.com/maps/api/geocode/json... instead of http://maps.google.com/maps/geo?output=json.... I've updated this project to reflect that.